### PR TITLE
Add observability stack and audit event ingestion

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,8 @@ services:
       - fintech-net
     volumes:
       - ./certs:/certs:ro
+    labels:
+      - "com.fintech.service=auth"
 
   account-service:
     build:
@@ -60,6 +62,8 @@ services:
       - fintech-net
     volumes:
       - ./certs:/certs:ro
+    labels:
+      - "com.fintech.service=account"
 
   transaction-service:
     build:
@@ -79,6 +83,8 @@ services:
       - fintech-net
     volumes:
       - ./certs:/certs:ro
+    labels:
+      - "com.fintech.service=transaction"
 
   audit-service:
     build:
@@ -96,6 +102,8 @@ services:
       - redis
     volumes:
       - ./certs:/certs:ro
+    labels:
+      - "com.fintech.service=audit"
 
   monitoring-service:
     build:
@@ -113,6 +121,80 @@ services:
       - redis
     volumes:
       - ./certs:/certs:ro
+    labels:
+      - "com.fintech.service=monitoring"
+
+  prometheus:
+    image: prom/prometheus:v2.48.0
+    container_name: prometheus
+    restart: unless-stopped
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./monitoring/alerts/alert_rules.yml:/etc/prometheus/alert_rules.yml:ro
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--web.enable-lifecycle"
+    ports:
+      - "9090:9090"
+    networks:
+      - fintech-net
+
+  alertmanager:
+    image: prom/alertmanager:v0.26.0
+    container_name: alertmanager
+    restart: unless-stopped
+    volumes:
+      - ./monitoring/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+    command:
+      - "--config.file=/etc/alertmanager/alertmanager.yml"
+    ports:
+      - "9093:9093"
+    networks:
+      - fintech-net
+
+  loki:
+    image: grafana/loki:2.9.3
+    container_name: loki
+    restart: unless-stopped
+    command: ["-config.file=/etc/loki/local-config.yml"]
+    volumes:
+      - ./logging/loki-config.yml:/etc/loki/local-config.yml:ro
+    ports:
+      - "3100:3100"
+    networks:
+      - fintech-net
+
+  promtail:
+    image: grafana/promtail:2.9.3
+    container_name: promtail
+    restart: unless-stopped
+    command: ["-config.file=/etc/promtail/config.yml"]
+    volumes:
+      - ./logging/promtail-config.yml:/etc/promtail/config.yml:ro
+      - promtail_positions:/tmp/promtail
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - fintech-net
+
+  grafana:
+    image: grafana/grafana:10.2.3
+    container_name: grafana
+    restart: unless-stopped
+    depends_on:
+      - prometheus
+      - loki
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_SECURITY_ALLOW_EMBEDDING: "true"
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards:ro
+    networks:
+      - fintech-net
 
 networks:
   fintech-net:
@@ -120,4 +202,6 @@ networks:
 
 volumes:
   postgres_data:
+    driver: local
+  promtail_positions:
     driver: local

--- a/logging/loki-config.yml
+++ b/logging/loki-config.yml
@@ -1,0 +1,30 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  http_listen_address: 0.0.0.0
+
+common:
+  path_prefix: /var/loki
+  storage:
+    filesystem:
+      chunks_directory: /var/loki/chunks
+      rules_directory: /var/loki/rules
+  replication_factor: 1
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: boltdb-shipper
+      object_store: filesystem
+      schema: v12
+      index:
+        prefix: index_
+        period: 24h
+
+ruler:
+  alertmanager_url: http://alertmanager:9093

--- a/logging/promtail-config.yml
+++ b/logging/promtail-config.yml
@@ -1,0 +1,32 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/promtail/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: docker-logs
+    pipeline_stages:
+      - json:
+          expressions:
+            event: event
+            trace_id: trace_id
+            compliance: compliance
+            client: client
+      - labels:
+          event:
+          trace_id:
+          client:
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+    relabel_configs:
+      - source_labels: ['__meta_docker_container_name']
+        target_label: container
+      - source_labels: ['__meta_docker_container_label_com_docker_compose_service']
+        target_label: service
+      - source_labels: ['__meta_docker_container_log_stream']
+        target_label: stream

--- a/monitoring/alertmanager.yml
+++ b/monitoring/alertmanager.yml
@@ -1,0 +1,8 @@
+route:
+  receiver: default
+
+receivers:
+  - name: default
+    webhook_configs:
+      - url: http://monitoring-service:8004/alerts
+        send_resolved: true

--- a/monitoring/alerts/alert_rules.yml
+++ b/monitoring/alerts/alert_rules.yml
@@ -1,0 +1,36 @@
+groups:
+  - name: fintech-operational-alerts
+    rules:
+      - alert: RateLimitBreached
+        expr: sum(increase(http_requests_total{status=~"429"}[5m])) by (service) > 20
+        for: 5m
+        labels:
+          severity: warning
+          compliance: pci-dss
+        annotations:
+          summary: "Rate limit breaches detected"
+          description: |
+            More than 20 HTTP 429 responses were returned by {{ $labels.service }} over 5 minutes.
+            Investigate potential abuse or misconfiguration.
+      - alert: FailedLoginSpike
+        expr: sum(increase(http_requests_total{service="auth-service",status=~"401|403"}[5m])) > 25
+        for: 5m
+        labels:
+          severity: critical
+          compliance: soc2
+        annotations:
+          summary: "Authentication failures trending upward"
+          description: |
+            Authentication failures against the auth-service exceeded the expected threshold
+            over the last 5 minutes. Review authentication logs for possible credential stuffing.
+      - alert: AnomalousTransactionVolume
+        expr: sum(rate(http_requests_total{service="transaction-service",method="POST",status=~"2.."}[10m])) > 50
+        for: 10m
+        labels:
+          severity: warning
+          compliance: aml
+        annotations:
+          summary: "Anomalous transaction volume detected"
+          description: |
+            The transaction-service processed more than 50 successful transaction submissions per minute
+            over the last 10 minutes. Verify whether this aligns with expected trading windows.

--- a/monitoring/grafana/dashboards/fintech_overview.json
+++ b/monitoring/grafana/dashboards/fintech_overview.json
@@ -1,0 +1,193 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "-- Grafana --",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le, service))",
+          "legendFormat": "{{service}}",
+          "refId": "A"
+        }
+      ],
+      "title": "P95 Request Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{status=~\"5..\"}[5m])) by (service) / sum(rate(http_requests_total[5m])) by (service)",
+          "legendFormat": "{{service}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Error Rate (5xx)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(http_requests_total{service=\"auth-service\",status=~\"401|403\"}[5m]))",
+          "legendFormat": "Auth failures",
+          "refId": "A"
+        }
+      ],
+      "title": "Authentication Failures",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(audit_events_total[15m])) by (category)",
+          "legendFormat": "{{category}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Compliance & Security Events",
+      "type": "timeseries"
+    }
+  ],
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [
+    "fintech",
+    "compliance"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "title": "Fintech Operational Overview",
+  "version": 1
+}

--- a/monitoring/grafana/provisioning/dashboards/dashboard.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+disableDeletion: false
+
+providers:
+  - name: fintech-dashboards
+    orgId: 1
+    folder: Fintech Operations
+    type: file
+    disableDeletion: false
+    options:
+      path: /var/lib/grafana/dashboards

--- a/monitoring/grafana/provisioning/datasources/datasource.yml
+++ b/monitoring/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,21 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    uid: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    jsonData:
+      timeInterval: 15s
+  - name: Loki
+    uid: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    jsonData:
+      derivedFields:
+        - name: traceID
+          matcherRegex: "trace_id\\":\\s*\"([a-f0-9-]+)\""
+          url: "$${__value.raw}"

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,45 @@
+global:
+  scrape_interval: 15s
+  scrape_timeout: 10s
+  evaluation_interval: 15s
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+            - alertmanager:9093
+
+rule_files:
+  - /etc/prometheus/alert_rules.yml
+
+scrape_configs:
+  - job_name: auth-service
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["auth-service:8000"]
+        labels:
+          service: auth-service
+  - job_name: account-service
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["account-service:8001"]
+        labels:
+          service: account-service
+  - job_name: transaction-service
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["transaction-service:8002"]
+        labels:
+          service: transaction-service
+  - job_name: audit-service
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["audit-service:8003"]
+        labels:
+          service: audit-service
+  - job_name: monitoring-service
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["monitoring-service:8004"]
+        labels:
+          service: monitoring-service

--- a/services/account_service/Dockerfile
+++ b/services/account_service/Dockerfile
@@ -13,7 +13,8 @@ RUN pip install --no-cache-dir \
     cryptography \
     fastapi-limiter \
     redis \
-    python-json-logger
+    python-json-logger \
+    prometheus-fastapi-instrumentator
 
 CMD [
     "uvicorn",

--- a/services/account_service/presentation/main.py
+++ b/services/account_service/presentation/main.py
@@ -4,10 +4,12 @@ from ..infrastructure.rate_limiting import register_rate_limiter
 
 from .api import router
 from .middleware import setup_middleware
+from .metrics import setup_metrics
 
 
 app = FastAPI(title="Account Service", version="0.2.0")
 setup_middleware(app)
+setup_metrics(app)
 register_rate_limiter(app)
 app.include_router(router)
 

--- a/services/account_service/presentation/metrics.py
+++ b/services/account_service/presentation/metrics.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from prometheus_client import Counter
+from prometheus_fastapi_instrumentator import Instrumentator
+
+REQUEST_COMPLIANCE_COUNTER = Counter(
+    "account_service_compliance_flags_total",
+    "Count of requests touching regulated data scopes.",
+    labelnames=("scope",),
+)
+
+
+def setup_metrics(app: FastAPI) -> None:
+    instrumentator = Instrumentator(
+        should_group_status_codes=True,
+        should_ignore_untemplated=True,
+        excluded_handlers={"/metrics", "/health"},
+    )
+    instrumentator.instrument(app)
+    instrumentator.expose(app, include_in_schema=False)
+
+    @app.middleware("http")
+    async def _compliance_counter(request, call_next):  # type: ignore[no-untyped-def]
+        scopes = request.headers.get("x-data-scope")
+        if scopes:
+            for scope in scopes.split(","):
+                REQUEST_COMPLIANCE_COUNTER.labels(scope=scope.strip()).inc()
+        return await call_next(request)

--- a/services/account_service/presentation/middleware.py
+++ b/services/account_service/presentation/middleware.py
@@ -29,6 +29,7 @@ class RequestIDMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         request_id = request.headers.get("X-Request-ID", str(uuid.uuid4()))
         request.state.request_id = request_id
+        request.state.trace_id = request_id
         response = await call_next(request)
         response.headers["X-Request-ID"] = request_id
         return response
@@ -51,9 +52,10 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
 
 
 class AccessLogMiddleware(BaseHTTPMiddleware):
-    def __init__(self, app: FastAPI, logger: logging.Logger):
+    def __init__(self, app: FastAPI, logger: logging.Logger, *, service_name: str):
         super().__init__(app)
         self._logger = logger
+        self._service_name = service_name
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         start = time.perf_counter()
@@ -83,6 +85,13 @@ class AccessLogMiddleware(BaseHTTPMiddleware):
             "duration_ms": round(duration * 1000, 3),
             "request_id": request_id,
             "client": request.client.host if request.client else None,
+            "trace_id": request_id,
+            "service": self._service_name,
+            "compliance": {
+                "regimes": ["gdpr", "pci_dss", "soc2"],
+                "data_classification": request.headers.get("x-data-classification", "internal"),
+            },
+            "mtls_subject": request.headers.get("x-mtls-client-cn"),
         }
         if exc:
             payload["error"] = str(exc)
@@ -153,6 +162,6 @@ def register_exception_handlers(app: FastAPI) -> None:
 def setup_middleware(app: FastAPI) -> None:
     logger = _configure_json_logger()
     app.add_middleware(RequestIDMiddleware)
-    app.add_middleware(AccessLogMiddleware, logger=logger)
+    app.add_middleware(AccessLogMiddleware, logger=logger, service_name=app.title)
     app.add_middleware(SecurityHeadersMiddleware)
     register_exception_handlers(app)

--- a/services/audit_service/Dockerfile
+++ b/services/audit_service/Dockerfile
@@ -11,7 +11,8 @@ RUN pip install --no-cache-dir \
     cryptography \
     fastapi-limiter \
     redis \
-    python-json-logger
+    python-json-logger \
+    prometheus-fastapi-instrumentator
 
 CMD [
     "uvicorn",

--- a/services/audit_service/domain/models.py
+++ b/services/audit_service/domain/models.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Mapping, Any
+from uuid import uuid4
+
+
+class AuditEventCategory(str, Enum):
+    SECURITY = "security"
+    TRANSACTION = "transaction"
+    COMPLIANCE = "compliance"
+    PLATFORM = "platform"
+
+
+@dataclass(slots=True, frozen=True)
+class AuditEvent:
+    id: str
+    category: AuditEventCategory
+    action: str
+    actor: str
+    principal: str | None
+    resource: str | None
+    severity: str
+    source_service: str
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    compliance_tags: tuple[str, ...] = field(default_factory=tuple)
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        category: AuditEventCategory,
+        action: str,
+        actor: str,
+        principal: str | None,
+        resource: str | None,
+        severity: str,
+        source_service: str,
+        metadata: Mapping[str, Any] | None = None,
+        compliance_tags: list[str] | tuple[str, ...] | None = None,
+    ) -> "AuditEvent":
+        return cls(
+            id=str(uuid4()),
+            category=category,
+            action=action,
+            actor=actor,
+            principal=principal,
+            resource=resource,
+            severity=severity,
+            source_service=source_service,
+            metadata=dict(metadata or {}),
+            compliance_tags=tuple(compliance_tags or ()),
+        )

--- a/services/audit_service/infrastructure/repository.py
+++ b/services/audit_service/infrastructure/repository.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Sequence
+
+from ..domain.models import AuditEvent
+
+
+class AuditEventRepository:
+    """In-memory append-only repository for audit events."""
+
+    def __init__(self) -> None:
+        self._events: list[AuditEvent] = []
+        self._lock = asyncio.Lock()
+
+    async def append(self, event: AuditEvent) -> AuditEvent:
+        async with self._lock:
+            self._events.append(event)
+        return event
+
+    async def list_events(self, limit: int | None = None) -> list[AuditEvent]:
+        async with self._lock:
+            snapshot: Sequence[AuditEvent] = tuple(self._events)
+        if limit is not None:
+            return list(snapshot[-limit:])
+        return list(snapshot)

--- a/services/audit_service/presentation/api.py
+++ b/services/audit_service/presentation/api.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from pydantic import BaseModel, Field
+
+from ..domain.models import AuditEvent, AuditEventCategory
+from ..infrastructure.repository import AuditEventRepository
+from .dependencies import (
+    get_audit_repository,
+    require_mutual_tls_identity,
+    require_scopes,
+)
+from .metrics import record_audit_event
+
+router = APIRouter(prefix="/audit", tags=["audit"])
+
+
+class AuditEventPayload(BaseModel):
+    category: AuditEventCategory
+    action: str = Field(..., min_length=1)
+    actor: str = Field(..., min_length=1)
+    principal: str | None = Field(default=None)
+    resource: str | None = Field(default=None)
+    severity: str = Field(default="info")
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    compliance_tags: list[str] = Field(default_factory=list)
+
+
+class AuditEventResponse(BaseModel):
+    id: str
+    created_at: datetime
+
+
+class AuditEventRead(BaseModel):
+    id: str
+    category: AuditEventCategory
+    action: str
+    actor: str
+    principal: str | None
+    resource: str | None
+    severity: str
+    source_service: str
+    metadata: dict[str, Any]
+    compliance_tags: tuple[str, ...]
+    created_at: datetime
+
+    @classmethod
+    def from_domain(cls, event: AuditEvent) -> "AuditEventRead":
+        return cls(
+            id=event.id,
+            category=event.category,
+            action=event.action,
+            actor=event.actor,
+            principal=event.principal,
+            resource=event.resource,
+            severity=event.severity,
+            source_service=event.source_service,
+            metadata=dict(event.metadata),
+            compliance_tags=tuple(event.compliance_tags),
+            created_at=event.created_at,
+        )
+
+
+@router.post(
+    "/events",
+    response_model=AuditEventResponse,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(require_scopes("audit:write"))],
+)
+async def record_event(
+    payload: AuditEventPayload,
+    repository: AuditEventRepository = Depends(get_audit_repository),
+    client_cn: str = Depends(require_mutual_tls_identity),
+) -> AuditEventResponse:
+    event = AuditEvent.create(
+        category=payload.category,
+        action=payload.action,
+        actor=payload.actor,
+        principal=payload.principal,
+        resource=payload.resource,
+        severity=payload.severity,
+        source_service=client_cn,
+        metadata=payload.metadata,
+        compliance_tags=payload.compliance_tags,
+    )
+    await repository.append(event)
+    record_audit_event(event.category.value, event.source_service)
+    return AuditEventResponse(id=event.id, created_at=event.created_at)
+
+
+@router.get(
+    "/events",
+    response_model=list[AuditEventRead],
+    dependencies=[Depends(require_scopes("audit:read"))],
+)
+async def list_events(
+    repository: AuditEventRepository = Depends(get_audit_repository),
+    limit: int = 100,
+) -> list[AuditEventRead]:
+    if limit <= 0 or limit > 500:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="limit must be between 1 and 500")
+    events = await repository.list_events(limit)
+    return [AuditEventRead.from_domain(event) for event in events]

--- a/services/audit_service/presentation/main.py
+++ b/services/audit_service/presentation/main.py
@@ -1,12 +1,16 @@
 from fastapi import Depends, FastAPI
 
 from ..infrastructure.rate_limiting import register_rate_limiter
+from .api import router
 from .dependencies import get_current_principal
 from .middleware import setup_middleware
+from .metrics import setup_metrics
 
 app = FastAPI(title="Audit Service", version="0.2.0")
 setup_middleware(app)
+setup_metrics(app)
 register_rate_limiter(app)
+app.include_router(router)
 
 
 @app.get("/health", tags=["health"], dependencies=[Depends(get_current_principal)])

--- a/services/audit_service/presentation/metrics.py
+++ b/services/audit_service/presentation/metrics.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from prometheus_client import Counter
+from prometheus_fastapi_instrumentator import Instrumentator
+
+AUDIT_EVENTS_COUNTER = Counter(
+    "audit_events_total",
+    "Number of audit events ingested by category and source.",
+    labelnames=("category", "source"),
+)
+
+
+def setup_metrics(app: FastAPI) -> None:
+    instrumentator = Instrumentator(
+        should_group_status_codes=True,
+        should_ignore_untemplated=True,
+        excluded_handlers={"/metrics", "/health"},
+    )
+    instrumentator.instrument(app)
+    instrumentator.expose(app, include_in_schema=False)
+
+
+def record_audit_event(category: str, source: str) -> None:
+    AUDIT_EVENTS_COUNTER.labels(category=category, source=source).inc()

--- a/services/audit_service/presentation/middleware.py
+++ b/services/audit_service/presentation/middleware.py
@@ -29,6 +29,7 @@ class RequestIDMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         request_id = request.headers.get("X-Request-ID", str(uuid.uuid4()))
         request.state.request_id = request_id
+        request.state.trace_id = request_id
         response = await call_next(request)
         response.headers["X-Request-ID"] = request_id
         return response
@@ -51,9 +52,10 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
 
 
 class AccessLogMiddleware(BaseHTTPMiddleware):
-    def __init__(self, app: FastAPI, logger: logging.Logger):
+    def __init__(self, app: FastAPI, logger: logging.Logger, *, service_name: str):
         super().__init__(app)
         self._logger = logger
+        self._service_name = service_name
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         start = time.perf_counter()
@@ -83,6 +85,13 @@ class AccessLogMiddleware(BaseHTTPMiddleware):
             "duration_ms": round(duration * 1000, 3),
             "request_id": request_id,
             "client": request.client.host if request.client else None,
+            "trace_id": request_id,
+            "service": self._service_name,
+            "compliance": {
+                "regimes": ["gdpr", "pci_dss", "soc2"],
+                "data_classification": request.headers.get("x-data-classification", "restricted"),
+            },
+            "mtls_subject": request.headers.get("x-mtls-client-cn"),
         }
         if exc:
             payload["error"] = str(exc)
@@ -153,6 +162,6 @@ def register_exception_handlers(app: FastAPI) -> None:
 def setup_middleware(app: FastAPI) -> None:
     logger = _configure_json_logger()
     app.add_middleware(RequestIDMiddleware)
-    app.add_middleware(AccessLogMiddleware, logger=logger)
+    app.add_middleware(AccessLogMiddleware, logger=logger, service_name=app.title)
     app.add_middleware(SecurityHeadersMiddleware)
     register_exception_handlers(app)

--- a/services/auth_service/Dockerfile
+++ b/services/auth_service/Dockerfile
@@ -14,7 +14,8 @@ RUN pip install --no-cache-dir \
     cryptography \
     fastapi-limiter \
     redis \
-    python-json-logger
+    python-json-logger \
+    prometheus-fastapi-instrumentator
 
 CMD [
     "uvicorn",

--- a/services/auth_service/presentation/main.py
+++ b/services/auth_service/presentation/main.py
@@ -6,6 +6,7 @@ from ..infrastructure.rate_limiting import register_rate_limiter
 from .api import router
 from .dependencies import decode_bearer_token, get_jwt_service
 from .middleware import setup_middleware
+from .metrics import setup_metrics
 
 
 oauth_flows = oauth2_base.OAuthFlowsModel(
@@ -25,6 +26,7 @@ app = FastAPI(
 )
 
 setup_middleware(app)
+setup_metrics(app)
 register_rate_limiter(app)
 app.include_router(router)
 

--- a/services/auth_service/presentation/metrics.py
+++ b/services/auth_service/presentation/metrics.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from prometheus_client import Counter
+from prometheus_fastapi_instrumentator import Instrumentator
+
+FAILED_LOGIN_COUNTER = Counter(
+    "auth_service_failed_logins_total",
+    "Count of failed authentication attempts grouped by client.",
+    labelnames=("client_id",),
+)
+
+
+def setup_metrics(app: FastAPI) -> None:
+    instrumentator = Instrumentator(
+        should_group_status_codes=True,
+        should_ignore_untemplated=True,
+        excluded_handlers={"/metrics", "/health"},
+    )
+    instrumentator.instrument(app)
+    instrumentator.expose(app, include_in_schema=False)
+
+    @app.middleware("http")
+    async def _failed_login_counter(request, call_next):  # type: ignore[no-untyped-def]
+        response = await call_next(request)
+        if request.url.path.startswith("/auth/") and response.status_code in {401, 403}:
+            FAILED_LOGIN_COUNTER.labels(
+                client_id=request.headers.get("x-client-id", "unknown")
+            ).inc()
+        return response

--- a/services/auth_service/presentation/middleware.py
+++ b/services/auth_service/presentation/middleware.py
@@ -29,6 +29,7 @@ class RequestIDMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         request_id = request.headers.get("X-Request-ID", str(uuid.uuid4()))
         request.state.request_id = request_id
+        request.state.trace_id = request_id
         response = await call_next(request)
         response.headers["X-Request-ID"] = request_id
         return response
@@ -51,9 +52,10 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
 
 
 class AccessLogMiddleware(BaseHTTPMiddleware):
-    def __init__(self, app: FastAPI, logger: logging.Logger):
+    def __init__(self, app: FastAPI, logger: logging.Logger, *, service_name: str):
         super().__init__(app)
         self._logger = logger
+        self._service_name = service_name
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         start = time.perf_counter()
@@ -83,6 +85,13 @@ class AccessLogMiddleware(BaseHTTPMiddleware):
             "duration_ms": round(duration * 1000, 3),
             "request_id": request_id,
             "client": request.client.host if request.client else None,
+            "trace_id": request_id,
+            "service": self._service_name,
+            "compliance": {
+                "regimes": ["gdpr", "pci_dss", "soc2"],
+                "data_classification": request.headers.get("x-data-classification", "internal"),
+            },
+            "mtls_subject": request.headers.get("x-mtls-client-cn"),
         }
         if exc:
             payload["error"] = str(exc)
@@ -153,6 +162,6 @@ def register_exception_handlers(app: FastAPI) -> None:
 def setup_middleware(app: FastAPI) -> None:
     logger = _configure_json_logger()
     app.add_middleware(RequestIDMiddleware)
-    app.add_middleware(AccessLogMiddleware, logger=logger)
+    app.add_middleware(AccessLogMiddleware, logger=logger, service_name=app.title)
     app.add_middleware(SecurityHeadersMiddleware)
     register_exception_handlers(app)

--- a/services/monitoring_service/Dockerfile
+++ b/services/monitoring_service/Dockerfile
@@ -11,7 +11,8 @@ RUN pip install --no-cache-dir \
     cryptography \
     fastapi-limiter \
     redis \
-    python-json-logger
+    python-json-logger \
+    prometheus-fastapi-instrumentator
 
 CMD [
     "uvicorn",

--- a/services/monitoring_service/presentation/api.py
+++ b/services/monitoring_service/presentation/api.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, status
+
+router = APIRouter()
+
+_alert_logger = logging.getLogger("alerts.webhook")
+
+
+@router.post(
+    "/alerts",
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def receive_alert(payload: dict[str, Any]) -> dict[str, str]:
+    alerts = payload.get("alerts", [])
+    _alert_logger.warning(
+        "alert_notification",
+        extra={
+            "alert_count": len(alerts),
+            "compliance": {"regimes": ["soc2", "pci_dss"]},
+        },
+    )
+    return {"status": "received"}

--- a/services/monitoring_service/presentation/main.py
+++ b/services/monitoring_service/presentation/main.py
@@ -1,12 +1,16 @@
 from fastapi import Depends, FastAPI
 
 from ..infrastructure.rate_limiting import register_rate_limiter
+from .api import router
 from .dependencies import get_current_principal
 from .middleware import setup_middleware
+from .metrics import setup_metrics
 
 app = FastAPI(title="Monitoring Service", version="0.2.0")
 setup_middleware(app)
+setup_metrics(app)
 register_rate_limiter(app)
+app.include_router(router)
 
 
 @app.get("/health", tags=["health"], dependencies=[Depends(get_current_principal)])

--- a/services/monitoring_service/presentation/metrics.py
+++ b/services/monitoring_service/presentation/metrics.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from prometheus_fastapi_instrumentator import Instrumentator
+
+
+def setup_metrics(app: FastAPI) -> None:
+    instrumentator = Instrumentator(
+        should_group_status_codes=True,
+        should_ignore_untemplated=True,
+        excluded_handlers={"/metrics", "/health"},
+    )
+    instrumentator.instrument(app)
+    instrumentator.expose(app, include_in_schema=False)

--- a/services/monitoring_service/presentation/middleware.py
+++ b/services/monitoring_service/presentation/middleware.py
@@ -29,6 +29,7 @@ class RequestIDMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         request_id = request.headers.get("X-Request-ID", str(uuid.uuid4()))
         request.state.request_id = request_id
+        request.state.trace_id = request_id
         response = await call_next(request)
         response.headers["X-Request-ID"] = request_id
         return response
@@ -51,9 +52,10 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
 
 
 class AccessLogMiddleware(BaseHTTPMiddleware):
-    def __init__(self, app: FastAPI, logger: logging.Logger):
+    def __init__(self, app: FastAPI, logger: logging.Logger, *, service_name: str):
         super().__init__(app)
         self._logger = logger
+        self._service_name = service_name
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         start = time.perf_counter()
@@ -83,6 +85,13 @@ class AccessLogMiddleware(BaseHTTPMiddleware):
             "duration_ms": round(duration * 1000, 3),
             "request_id": request_id,
             "client": request.client.host if request.client else None,
+            "trace_id": request_id,
+            "service": self._service_name,
+            "compliance": {
+                "regimes": ["gdpr", "pci_dss", "soc2"],
+                "data_classification": request.headers.get("x-data-classification", "internal"),
+            },
+            "mtls_subject": request.headers.get("x-mtls-client-cn"),
         }
         if exc:
             payload["error"] = str(exc)
@@ -152,7 +161,12 @@ def register_exception_handlers(app: FastAPI) -> None:
 
 def setup_middleware(app: FastAPI) -> None:
     logger = _configure_json_logger()
+    alert_logger = logging.getLogger("alerts.webhook")
+    if not alert_logger.handlers:
+        for handler in logger.handlers:
+            alert_logger.addHandler(handler)
+    alert_logger.setLevel(logging.INFO)
     app.add_middleware(RequestIDMiddleware)
-    app.add_middleware(AccessLogMiddleware, logger=logger)
+    app.add_middleware(AccessLogMiddleware, logger=logger, service_name=app.title)
     app.add_middleware(SecurityHeadersMiddleware)
     register_exception_handlers(app)

--- a/services/transaction_service/Dockerfile
+++ b/services/transaction_service/Dockerfile
@@ -13,7 +13,8 @@ RUN pip install --no-cache-dir \
     cryptography \
     fastapi-limiter \
     redis \
-    python-json-logger
+    python-json-logger \
+    prometheus-fastapi-instrumentator
 
 CMD [
     "uvicorn",

--- a/services/transaction_service/presentation/main.py
+++ b/services/transaction_service/presentation/main.py
@@ -4,10 +4,12 @@ from ..infrastructure.rate_limiting import register_rate_limiter
 
 from .api import router
 from .middleware import setup_middleware
+from .metrics import setup_metrics
 
 
 app = FastAPI(title="Transaction Service", version="0.2.0")
 setup_middleware(app)
+setup_metrics(app)
 register_rate_limiter(app)
 app.include_router(router)
 

--- a/services/transaction_service/presentation/metrics.py
+++ b/services/transaction_service/presentation/metrics.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from prometheus_client import Counter
+from prometheus_fastapi_instrumentator import Instrumentator
+
+TRANSACTION_VOLUME_COUNTER = Counter(
+    "transaction_service_submissions_total",
+    "Number of transaction submissions processed.",
+    labelnames=("status",),
+)
+
+
+def setup_metrics(app: FastAPI) -> None:
+    instrumentator = Instrumentator(
+        should_group_status_codes=True,
+        should_ignore_untemplated=True,
+        excluded_handlers={"/metrics", "/health"},
+    )
+    instrumentator.instrument(app)
+    instrumentator.expose(app, include_in_schema=False)
+
+    @app.middleware("http")
+    async def _transaction_volume(request, call_next):  # type: ignore[no-untyped-def]
+        response = await call_next(request)
+        if request.url.path.startswith("/transactions") and request.method == "POST":
+            status = "success" if response.status_code < 400 else "failed"
+            TRANSACTION_VOLUME_COUNTER.labels(status=status).inc()
+        return response


### PR DESCRIPTION
## Summary
- add Prometheus, Alertmanager, Grafana, and Loki/Promtail services with provisioning, alert rules, and dashboards for latency, error, auth, and compliance KPIs
- instrument every FastAPI service with Prometheus metrics endpoints and structured access logging that includes trace IDs, mTLS subjects, and compliance metadata
- implement an append-only audit event domain model with an `/audit/events` API and Prometheus counters for ingested security and transaction events

## Testing
- python -m compileall services

------
https://chatgpt.com/codex/tasks/task_e_68e57cbe1b4c83339e9a3101912df882