### PR TITLE
Fix redis dependency conflict in dev requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ uvicorn[standard]==0.29.0
 sqlmodel==0.0.18
 sqlalchemy[asyncio]==2.0.29
 asyncpg==0.29.0
-redis==5.0.3
+redis==4.6.0
 fastapi-limiter==0.1.5
 PyJWT[crypto]==2.8.0
 testcontainers[postgresql]==3.7.1


### PR DESCRIPTION
## Summary
- downgrade the redis dependency to 4.6.0 to restore compatibility with fastapi-limiter 0.1.5

## Testing
- not run (dependency-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e573f5ce508333adbe7fc1388756ae