### PR TITLE
Limit CI compose services and add startup diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,11 +42,12 @@ jobs:
         run: pytest
 
       - name: Start services
+        id: start_services
         run: |
           set -euo pipefail
-          docker compose up --build -d
+          services="postgres redis auth-service account-service transaction-service audit-service monitoring-service"
+          docker compose up --build -d ${services}
           echo "Waiting for services to become healthy..."
-          services=$(docker compose config --services)
           if [ -z "${services}" ]; then
             echo "No services defined in docker-compose.yml"
             exit 1
@@ -78,6 +79,17 @@ jobs:
             docker compose ps
             exit 1
           fi
+
+      - name: Debug services on startup failure
+        if: failure() && steps.start_services.outcome == 'failure'
+        run: |
+          set -euo pipefail
+          echo "Docker ps -a:"
+          docker ps -a || true
+          for service in postgres redis auth-service account-service transaction-service audit-service monitoring-service; do
+            echo "Logs for ${service}:"
+            docker logs ${service} || true
+          done
 
       - name: Run Newman collection with retries
         env:


### PR DESCRIPTION
## Summary
- start only core application services in the CI docker compose invocation to avoid monitoring container failures
- add a dedicated debug step to print container status and logs when service startup fails

## Testing
- not run (CI configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68e667eafab08333bdb9f77c1a62e66e