### PR TITLE
Fix PYTHONPATH for pytest in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,9 @@ jobs:
       - name: Run pytest with coverage
         id: tests
         continue-on-error: true
-        run: pytest
+        run: |
+          export PYTHONPATH="$PYTHONPATH:$(pwd)"
+          pytest
 
       - name: Start services
         id: start_services


### PR DESCRIPTION
## Summary
- ensure the project root is added to PYTHONPATH before running pytest in CI

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e66b60ddd08333873da2119eb44f73