### PR TITLE
Fix Pydantic TransactionRead instantiation in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,18 +1,13 @@
 from __future__ import annotations
 
-import asyncio
-from collections.abc import AsyncIterator, Generator
+from collections.abc import AsyncIterator
 from typing import Any
 
 import pytest
 
 
-@pytest.fixture(scope="session")
-def event_loop() -> Generator[asyncio.AbstractEventLoop, None, None]:
-    """Create an event loop for the entire pytest session."""
-    loop = asyncio.new_event_loop()
-    yield loop
-    loop.close()
+# pytest-asyncio>=0.23 provides a session-scoped loop by default, so we can
+# rely on its built-in fixture instead of redefining ``event_loop``.
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- update security sanitization test to validate domain Transaction objects into TransactionRead via Pydantic v2 APIs
- remove the custom event_loop fixture so pytest-asyncio's default loop is used and the deprecation warning disappears

## Testing
- not run (pytest-asyncio is not installed in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68e66dd682848333ab538f436d336208