### PR TITLE
Ensure asyncpg driver usage for database connections

### DIFF
--- a/services/account_service/infrastructure/repositories.py
+++ b/services/account_service/infrastructure/repositories.py
@@ -4,6 +4,7 @@ import os
 from contextlib import asynccontextmanager
 from typing import AsyncIterator, Optional
 
+from sqlalchemy.engine import make_url
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.future import select
 from sqlmodel import SQLModel
@@ -17,10 +18,27 @@ DATABASE_URL = os.getenv(
 )
 
 
+def _normalize_database_url(url: str) -> str:
+    """Ensure the SQLAlchemy URL uses the asyncpg driver."""
+    url_obj = make_url(url)
+    if "asyncpg" not in url_obj.drivername:
+        url_obj = url_obj.set(drivername="postgresql+asyncpg")
+    return str(url_obj)
+
+
+def _connect_args() -> dict[str, object]:
+    ssl_mode = os.getenv("ACCOUNT_DATABASE_SSLMODE", "require").lower()
+    if ssl_mode in {"disable", "disabled", "off", "false", "0"}:
+        return {}
+    if ssl_mode in {"require", "true", "on", "1"}:
+        return {"ssl": True}
+    raise RuntimeError(f"Unsupported ACCOUNT_DATABASE_SSLMODE value: {ssl_mode}")
+
+
 engine = create_async_engine(
-    DATABASE_URL,
+    _normalize_database_url(DATABASE_URL),
     echo=False,
-    connect_args={"ssl": "require"},
+    connect_args=_connect_args(),
 )
 async_session_factory = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
 

--- a/tests/integration/test_transaction_repository.py
+++ b/tests/integration/test_transaction_repository.py
@@ -5,6 +5,7 @@ import os
 
 import pytest
 from sqlalchemy import text
+from sqlalchemy.engine import make_url
 from testcontainers.postgres import PostgresContainer
 
 from services.transaction_service.domain.models import Transaction
@@ -15,9 +16,9 @@ from services.transaction_service.infrastructure import repositories
 @pytest.mark.asyncio
 async def test_transaction_repository_crud_flow() -> None:
     with PostgresContainer("postgres:15-alpine") as postgres:
-        sync_url = postgres.get_connection_url()
-        async_url = sync_url.replace("postgresql://", "postgresql+asyncpg://")
-        os.environ["TRANSACTION_DATABASE_URL"] = async_url
+        sync_url = make_url(postgres.get_connection_url())
+        async_url = sync_url.set(drivername="postgresql+asyncpg")
+        os.environ["TRANSACTION_DATABASE_URL"] = str(async_url)
         os.environ["TRANSACTION_DATABASE_SSLMODE"] = "disable"
 
         repo_module = importlib.reload(repositories)


### PR DESCRIPTION
## Summary
- normalize database URLs in the account and transaction repositories so SQLAlchemy always uses the asyncpg driver
- add configurable SSL handling for the account repository to mirror the transaction repository behaviour
- update the transaction repository integration test to rewrite the Testcontainers URL with SQLAlchemy utilities

## Testing
- `pytest -o addopts="" tests/unit/test_transaction_service.py` *(fails: missing pytest-cov/pytest-asyncio plugins in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e670ba1d5c833385443fd354f3ef2f