### PR TITLE
Fix PostgresContainer user attribute in integration test

### DIFF
--- a/tests/integration/test_transaction_repository.py
+++ b/tests/integration/test_transaction_repository.py
@@ -31,7 +31,9 @@ async def test_transaction_repository_crud_flow() -> None:
 
         # Surface the normalized credentials for any code path that reads the
         # standard Postgres environment variables during the test run.
-        os.environ["POSTGRES_USER"] = postgres.username
+        # ``testcontainers`` 3.x renamed ``username`` to ``user``; use the new
+        # attribute so the test works with modern releases.
+        os.environ["POSTGRES_USER"] = postgres.user
         os.environ["POSTGRES_PASSWORD"] = postgres.password
 
         repo_module = importlib.reload(repositories)


### PR DESCRIPTION
## Summary
- update the transaction repository integration test to use the current PostgresContainer.user attribute
- document the API change from testcontainers 3.x so the environment variables stay in sync with the container credentials

## Testing
- not run (tests not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e67555fc848333a1ff20c222ee7d9c