### PR TITLE
Normalize Postgres credentials in transaction repository integration test

### DIFF
--- a/tests/integration/test_transaction_repository.py
+++ b/tests/integration/test_transaction_repository.py
@@ -31,6 +31,16 @@ async def test_transaction_repository_crud_flow() -> None:
 
     with PostgresContainer("postgres:15-alpine") as postgres:
         sync_url = make_url(postgres.get_connection_url())
+        # Ensure the URL matches the credentials that we configured via
+        # environment variables.  ``PostgresContainer`` exposes the default
+        # ``test`` credentials even when custom ones are provided through the
+        # environment, so we normalize the URL here to keep it in sync with the
+        # running container configuration.
+        sync_url = sync_url.set(
+            username=credentials["POSTGRES_USER"],
+            password=credentials["POSTGRES_PASSWORD"],
+            database=credentials["POSTGRES_DB"],
+        )
         async_url = sync_url.set(drivername="postgresql+asyncpg")
         os.environ["TRANSACTION_DATABASE_URL"] = str(async_url)
         os.environ["TRANSACTION_DATABASE_SSLMODE"] = "disable"


### PR DESCRIPTION
## Summary
- normalize the integration test connection URL so it matches the custom Postgres credentials configured through environment variables

## Testing
- pytest tests/integration/test_transaction_repository.py -q -o addopts= *(fails: pytest configuration requires asyncio plugin unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e67ebfec8c833384a2e61d477daf30