### PR TITLE
Ensure integration test uses deterministic Postgres credentials

### DIFF
--- a/tests/integration/test_transaction_repository.py
+++ b/tests/integration/test_transaction_repository.py
@@ -15,21 +15,51 @@ from services.transaction_service.infrastructure import repositories
 @pytest.mark.integration
 @pytest.mark.asyncio
 async def test_transaction_repository_crud_flow() -> None:
-    with PostgresContainer("postgres:15-alpine") as postgres:
-        sync_url = make_url(postgres.get_connection_url())
+    # Explicit credentials prevent a mismatch between the async engine and the
+    # Postgres container.  Older testcontainers releases boot with the
+    # hard-coded ``test``/``test`` combination while newer releases default to
+    # ``postgres``/``postgres``.  Pinning the desired values ahead of time keeps
+    # both sides aligned regardless of the library version under test.
+    requested_credentials = {
+        "POSTGRES_USER": "integration_user",
+        "POSTGRES_PASSWORD": "integration_password",
+        "POSTGRES_DB": "integration_db",
+    }
+
+    postgres = PostgresContainer("postgres:15-alpine")
+    for key, value in requested_credentials.items():
+        # ``with_env`` works across testcontainers v2/v3 and ensures that the
+        # container starts with the exact credentials our test expects instead of
+        # relying on library defaults that may oscillate between ``test`` and
+        # ``postgres`` across releases.
+        postgres.with_env(key, value)
+
+    with postgres as container:
+        sync_url = make_url(container.get_connection_url())
         credentials = {
-            "POSTGRES_USER": sync_url.username or "",
-            "POSTGRES_PASSWORD": sync_url.password or "",
-            "POSTGRES_DB": sync_url.database or "",
+            "POSTGRES_USER": sync_url.username or requested_credentials["POSTGRES_USER"],
+            "POSTGRES_PASSWORD": sync_url.password or requested_credentials["POSTGRES_PASSWORD"],
+            "POSTGRES_DB": sync_url.database or requested_credentials["POSTGRES_DB"],
         }
+
+        # ``PostgresContainer`` may override our requested credentials depending on
+        # the library version.  Logging the derived values makes it easier to
+        # debug authentication mismatches in CI should they ever resurface.
+        print(
+            "Using Postgres container credentials:",
+            {key: ("***" if key == "POSTGRES_PASSWORD" else value) for key, value in credentials.items()},
+        )
+
         async_url = sync_url.set(drivername="postgresql+asyncpg")
+        async_url = async_url.set(username=credentials["POSTGRES_USER"], password=credentials["POSTGRES_PASSWORD"])
         os.environ["TRANSACTION_DATABASE_URL"] = str(async_url)
         os.environ["TRANSACTION_DATABASE_SSLMODE"] = "disable"
 
         # Surface the normalized credentials for any code path that reads the
-        # standard Postgres environment variables during the test run.  We reuse
-        # the local ``credentials`` mapping to align with testcontainers-postgres
-        # 3.x's ``env`` handling while keeping the async configuration intact.
+        # standard Postgres environment variables during the test run.  The
+        # environment variables are kept in sync with the container's real
+        # configuration so that asyncpg and SQLAlchemy always authenticate with
+        # matching values.
         os.environ["POSTGRES_USER"] = credentials["POSTGRES_USER"]
         os.environ["POSTGRES_PASSWORD"] = credentials["POSTGRES_PASSWORD"]
         os.environ["POSTGRES_DB"] = credentials["POSTGRES_DB"]


### PR DESCRIPTION
## Summary
- configure the Postgres test container with explicit credentials before startup
- propagate the resolved credentials to the async SQLAlchemy URL and standard environment variables
- add logging and inline documentation to clarify the credential alignment requirement

## Testing
- ⚠️ `pytest tests/integration/test_transaction_repository.py::test_transaction_repository_crud_flow -q`
  - blocked by missing pytest-cov dependency enforced via pytest.ini in this environment


------
https://chatgpt.com/codex/tasks/task_e_68e683b593888333b16d7c842150afed