### PR TITLE
Fix transaction repository credential defaults and add asyncio test shim

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+from collections.abc import Awaitable
+from typing import Any, Callable
+
+import pytest
+
+
+_DEFAULT_ASYNCIO_MODE = "auto"
+
+
+def pytest_addoption(parser: Any) -> None:  # pragma: no cover - exercised via integration tests
+    group = parser.getgroup("asyncio")
+    group.addoption(
+        "--asyncio-mode",
+        action="store",
+        dest="asyncio_mode_cli",
+        default=None,
+        help="Compatibility shim for pytest-asyncio's --asyncio-mode option.",
+    )
+    parser.addini(
+        "asyncio_mode",
+        "Compatibility shim for pytest-asyncio's asyncio_mode setting.",
+        default=_DEFAULT_ASYNCIO_MODE,
+    )
+
+
+def pytest_configure(config: Any) -> None:
+    config.addinivalue_line(
+        "markers",
+        "asyncio: mark a test as requiring an asyncio event loop",
+    )
+
+
+@pytest.fixture
+def event_loop() -> asyncio.AbstractEventLoop:
+    loop = asyncio.new_event_loop()
+    try:
+        asyncio.set_event_loop(loop)
+        yield loop
+        loop.run_until_complete(loop.shutdown_asyncgens())
+    finally:
+        asyncio.set_event_loop(None)
+        loop.close()
+
+
+def _should_run_async(pyfuncitem: pytest.Function) -> bool:
+    if inspect.iscoroutinefunction(pyfuncitem.obj):
+        return True
+    return pyfuncitem.get_closest_marker("asyncio") is not None
+
+
+def _call_in_loop(
+    loop: asyncio.AbstractEventLoop,
+    coro_func: Callable[..., Awaitable[Any]],
+    kwargs: dict[str, Any],
+) -> Any:
+    return loop.run_until_complete(coro_func(**kwargs))
+
+
+def pytest_pyfunc_call(pyfuncitem: pytest.Function) -> bool | None:
+    if not _should_run_async(pyfuncitem):
+        return None
+
+    loop = pyfuncitem.funcargs.get("event_loop")
+    owns_loop = loop is None
+
+    if owns_loop:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+    try:
+        _call_in_loop(loop, pyfuncitem.obj, pyfuncitem.funcargs)
+    finally:
+        if owns_loop and loop is not None:
+            try:
+                loop.run_until_complete(loop.shutdown_asyncgens())
+            finally:
+                asyncio.set_event_loop(None)
+                loop.close()
+
+    return True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,8 +6,8 @@ from typing import Any
 import pytest
 
 
-# pytest-asyncio>=0.23 provides a session-scoped loop by default, so we can
-# rely on its built-in fixture instead of redefining ``event_loop``.
+# The repository-level pytest shim supplies an ``event_loop`` fixture so the
+# tests can run without depending on the external pytest-asyncio plugin.
 
 
 @pytest.fixture

--- a/tests/integration/test_transaction_repository.py
+++ b/tests/integration/test_transaction_repository.py
@@ -22,9 +22,9 @@ async def test_transaction_repository_crud_flow() -> None:
     # time prevents the library from oscillating between the two, eliminating
     # authentication mismatches regardless of the version under test.
     requested_credentials = {
-        "POSTGRES_USER": "postgres" | "test",
-        "POSTGRES_PASSWORD": "postgres" | "test",
-        "POSTGRES_DB": "postgres" | "test",
+        "POSTGRES_USER": "postgres",
+        "POSTGRES_PASSWORD": "postgres",
+        "POSTGRES_DB": "postgres",
     }
 
     # Passing the credentials directly to ``PostgresContainer`` guarantees that


### PR DESCRIPTION
## Summary
- add a lightweight pytest plugin so async tests run without pytest-asyncio
- correct the transaction repository integration test credentials to avoid TypeError

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest --override-ini="addopts="

------
https://chatgpt.com/codex/tasks/task_e_68f6884c31248333bfcef53802f9b882